### PR TITLE
Fix environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,11 +4,12 @@ channels:
   - ioos
   - conda-forge
 dependencies:
+  - python=2.7
+  #- oceans
   - cartopy
   - folium
   - mpld3
   - numpy
-  - oceans
   - pandas
   - pillow
   - scipy


### PR DESCRIPTION
The `oceans` module is trying pull `iris` that is not in the `conda-forge` yet (and being re-built at the IOOS channel due to an issue we had at the migration).

Since it is not used your notebook I just removed it (and pinned python to 2.7) so you can build you binder.
